### PR TITLE
Update example packages

### DIFF
--- a/examples/next-shadcn.js/package.json
+++ b/examples/next-shadcn.js/package.json
@@ -18,18 +18,18 @@
     "radix-ui": "^1.4.3",
     "react": "19.2.3",
     "react-dom": "19.2.3",
-    "tailwind-merge": "^3.4.0"
+    "tailwind-merge": "^3.4.0",
+    "tailwindcss": "^4",
+    "@tailwindcss/postcss": "^4",
+    "tw-animate-css": "^1.4.0"
   },
   "devDependencies": {
-    "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
     "shadcn": "^3.8.4",
-    "tailwindcss": "^4",
-    "tw-animate-css": "^1.4.0",
     "typescript": "^5"
   }
 }

--- a/examples/next-shadcn.js/pnpm-lock.yaml
+++ b/examples/next-shadcn.js/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@handsontable/react-wrapper':
         specifier: 0.0.0-next-08b099a-20260210
         version: 0.0.0-next-08b099a-20260210(handsontable@0.0.0-next-08b099a-20260210)
+      '@tailwindcss/postcss':
+        specifier: ^4
+        version: 4.1.18
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -38,10 +41,13 @@ importers:
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
-    devDependencies:
-      '@tailwindcss/postcss':
+      tailwindcss:
         specifier: ^4
         version: 4.1.18
+      tw-animate-css:
+        specifier: ^1.4.0
+        version: 1.4.0
+    devDependencies:
       '@types/node':
         specifier: ^20
         version: 20.19.33
@@ -60,12 +66,6 @@ importers:
       shadcn:
         specifier: ^3.8.4
         version: 3.8.4(@types/node@20.19.33)(typescript@5.9.3)
-      tailwindcss:
-        specifier: ^4
-        version: 4.1.18
-      tw-animate-css:
-        specifier: ^1.4.0
-        version: 1.4.0
       typescript:
         specifier: ^5
         version: 5.9.3


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Dependency metadata/lockfile-only change in an example app; main risk is build/runtime packaging differences due to moving Tailwind tooling to `dependencies`.
> 
> **Overview**
> Updates `examples/next-shadcn.js` to treat Tailwind build tooling as app `dependencies` (moves `tailwindcss`, `@tailwindcss/postcss`, and `tw-animate-css` out of `devDependencies`).
> 
> Regenerates `pnpm-lock.yaml` to reflect the dependency section changes (no version bumps beyond the same resolved `4.1.18`/`1.4.0` already present).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5e4a792748e92acb6c0f43a225897f9804b371f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->