### PR TITLE
Add CodeSandbox configuration files for Ant Design example

### DIFF
--- a/examples/ant-design/.codesandbox/tasks.json
+++ b/examples/ant-design/.codesandbox/tasks.json
@@ -1,0 +1,34 @@
+{
+  // These tasks will run in order when initializing your CodeSandbox project.
+  "setupTasks": [
+    {
+      "name": "Install Dependencies",
+      "command": "npm install"
+    }
+  ],
+
+  // These tasks can be run from CodeSandbox. Running one will open a log in the app.
+  "tasks": {
+    "dev": {
+      "name": "Vite Dev",
+      "command": "npm run dev",
+      "runAtStart": true,
+      "preview": {
+        "port": 5173
+      }
+    },
+    "build": {
+      "name": "Build",
+      "command": "npm run build",
+      "runAtStart": false
+    },
+    "install": {
+      "name": "Install Dependencies",
+      "command": "npm install",
+      "restartOn": {
+        "files": ["package.json"],
+        "branch": false
+      }
+    }
+  }
+}

--- a/examples/ant-design/.codesandbox/template.json
+++ b/examples/ant-design/.codesandbox/template.json
@@ -1,0 +1,14 @@
+{
+  "title": "Handsontable + Ant Design",
+  "description": "Handsontable with Ant Design (React + Vite)",
+  "iconUrl": "https://raw.githubusercontent.com/codesandbox/sandbox-templates/main/vue-vite/.codesandbox/icon.png",
+  "tags": [
+    "frontend",
+    "react",
+    "vite",
+    "handsontable",
+    "antd",
+    "javascript"
+  ],
+  "published": true
+}

--- a/examples/ant-design/.codesandbox/workspace.json
+++ b/examples/ant-design/.codesandbox/workspace.json
@@ -1,0 +1,4 @@
+{
+  "openPreviews": [":5173"],
+  "activeFile": "/src/App.jsx"
+}

--- a/examples/ant-design/vite.config.js
+++ b/examples/ant-design/vite.config.js
@@ -3,6 +3,9 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  server: {
+    allowedHosts: true, // CodeSandbox preview hosts (*.csb.app)
+  },
   optimizeDeps: {
     include: ['handsontable', '@handsontable/react-wrapper', 'antd'],
   },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Only affects the Ant Design example’s sandbox metadata and dev server host allowlist; no production logic or data/security flows are changed.
> 
> **Overview**
> Adds a `.codesandbox` configuration to `examples/ant-design` (template metadata, workspace defaults, and runnable `dev`/`build`/`install` tasks) so the recipe initializes and previews correctly in CodeSandbox.
> 
> Updates `vite.config.js` to allow CodeSandbox preview hosts via `server.allowedHosts`, keeping the existing dependency pre-bundling list intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8048b339bb68923f87ad4126607554e6424b51f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->