### PR TITLE
Update server examples

### DIFF
--- a/server-examples/django/frontend/src/main.js
+++ b/server-examples/django/frontend/src/main.js
@@ -1,6 +1,4 @@
 import Handsontable from 'handsontable/base';
-import 'handsontable/styles/handsontable.min.css';
-import 'handsontable/styles/ht-theme-main.min.css';
 
 import {
   registerPlugin,
@@ -82,8 +80,6 @@ function buildUrl({ page, pageSize, sort, filters }) {
 const container = document.querySelector('#example1');
 
 const hot = new Handsontable(container, {
-  themeName: 'ht-theme-main',
-
   dataProvider: {
     // rowId tells dataProvider which field uniquely identifies each row.
     // Django's auto-increment primary key is used here.

--- a/server-examples/laravel/frontend/src/main.js
+++ b/server-examples/laravel/frontend/src/main.js
@@ -1,6 +1,5 @@
 import Handsontable from 'handsontable/base';
 import { registerAllModules } from 'handsontable/registry';
-import 'handsontable/dist/handsontable.full.min.css';
 
 registerAllModules();
 
@@ -46,6 +45,8 @@ function csrfToken() {
 }
 
 const container = document.querySelector('#example1');
+
+let removeConfirmed = false;
 
 const hot = new Handsontable(container, {
   dataProvider: {
@@ -97,12 +98,40 @@ const hot = new Handsontable(container, {
     },
   },
 
-  // Return false to cancel the operation before it reaches the server.
+  // beforeRowsMutation is sync (checks for a strict `=== false` return), so
+  // we can't await an async prompt inline. Instead: cancel the original
+  // attempt, show a notification with Delete/Cancel actions, and on Delete
+  // re-issue the remove via the DataProvider API. The flag lets the second
+  // pass through without re-prompting.
   beforeRowsMutation(operation, payload) {
-    if (operation === 'remove') {
+    if (operation === 'remove' && !removeConfirmed) {
       const count = payload.rowsRemove.length;
-      // eslint-disable-next-line no-alert
-      return window.confirm(`Delete ${count} row${count !== 1 ? 's' : ''}? This cannot be undone.`);
+      const notification = hot.getPlugin('notification');
+      const id = notification.showMessage({
+        variant: 'warning',
+        title: 'Delete rows',
+        message: `Delete ${count} row${count !== 1 ? 's' : ''}? This cannot be undone.`,
+        duration: 0,
+        actions: [
+          {
+            label: 'Delete',
+            type: 'primary',
+            callback: () => {
+              notification.hide(id);
+              removeConfirmed = true;
+              hot.getPlugin('dataProvider').removeRows(payload.rowsRemove).finally(() => {
+                removeConfirmed = false;
+              });
+            },
+          },
+          {
+            label: 'Cancel',
+            type: 'secondary',
+            callback: () => notification.hide(id),
+          },
+        ],
+      });
+      return false;
     }
   },
 
@@ -114,6 +143,8 @@ const hot = new Handsontable(container, {
   emptyDataState: true,
   notification: true,
 
+  width: '100%',
+  height: 'auto',
   rowHeaders: true,
   colHeaders: ['Name', 'SKU', 'Category', 'Price', 'Stock'],
   columns: [

--- a/server-examples/nestjs/client/src/main.js
+++ b/server-examples/nestjs/client/src/main.js
@@ -1,7 +1,5 @@
 import Handsontable from 'handsontable/base';
 import { registerAllModules } from 'handsontable/registry';
-import 'handsontable/styles/handsontable.min.css';
-import 'handsontable/styles/ht-theme-main.min.css';
 
 registerAllModules();
 

--- a/server-examples/rails/frontend/src/main.js
+++ b/server-examples/rails/frontend/src/main.js
@@ -1,6 +1,4 @@
 import Handsontable from 'handsontable/base';
-import 'handsontable/styles/handsontable.min.css';
-import 'handsontable/styles/ht-theme-main.min.css';
 
 import {
   registerCellType,

--- a/server-examples/spring/frontend/src/example1.js
+++ b/server-examples/spring/frontend/src/example1.js
@@ -1,4 +1,3 @@
-import 'handsontable/dist/handsontable.full.min.css';
 import Handsontable from 'handsontable/base';
 import { registerAllModules } from 'handsontable/registry';
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk example-only frontend changes; main behavior change is Laravel row-delete confirmation flow, which could affect UX but not core application logic.
> 
> **Overview**
> Updates the server example frontends to stop importing Handsontable bundled/theme CSS (and removes `themeName` usage in the Django example), relying on the surrounding setup for styling instead.
> 
> Improves the Laravel example’s row deletion UX by replacing the blocking `window.confirm` with a Handsontable `notification`-based confirm/cancel prompt wired through `beforeRowsMutation`, and sets the grid to auto-size (`width: '100%'`, `height: 'auto'`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 108528414a5ad5c1db7eb238ff56511ded30c558. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->