### PR TITLE
Validate template ID for CodeSandbox VM endpoint

### DIFF
--- a/render-ms/index.js
+++ b/render-ms/index.js
@@ -308,6 +308,13 @@ app.get("/codesandbox-vm", async (req, res) => {
 
     const templateId = packageJson.config?.codesandbox?.templateId;
 
+    if (!templateId) {
+      return res.status(400).json({
+        error:
+          "This example cannot be opened via /codesandbox-vm: add package.json config.codesandbox.templateId (CodeSandbox template id) for dynamic sandbox creation.",
+      });
+    }
+
     const filesToUpload = Object.fromEntries(
       files.filter((file) => {
         if (file.path.includes("package.json")) return false;
@@ -321,37 +328,35 @@ app.get("/codesandbox-vm", async (req, res) => {
       }),
     );
 
-    if (templateId) {
-      // Create a sandbox from your custom template
-      let sandbox = await sdk.sandboxes.create({
-        title: `Handsontable Example ${exampleDir} ${version}`,
-        public: true,
-        tags: tags,
-        id: templateId,
-        privacy: "public",
-      });
+    // Create a sandbox from your custom template
+    let sandbox = await sdk.sandboxes.create({
+      title: `Handsontable Example ${exampleDir} ${version}`,
+      public: true,
+      tags: tags,
+      id: templateId,
+      privacy: "public",
+    });
 
-      const client = await sandbox.connect();
+    const client = await sandbox.connect();
 
-      await client.fs.writeTextFile(
-        "package.json",
-        JSON.stringify(packageJson, null, 2),
-      );
+    await client.fs.writeTextFile(
+      "package.json",
+      JSON.stringify(packageJson, null, 2),
+    );
 
-      await Promise.all(
-        Object.entries(filesToUpload).map(([key, value]) => {
-          return client.fs.writeTextFile(key, value.content);
-        }),
-      );
+    await Promise.all(
+      Object.entries(filesToUpload).map(([key, value]) => {
+        return client.fs.writeTextFile(key, value.content);
+      }),
+    );
 
-      const tasks = await client.tasks.getAll();
-      await runCodesandboxInstallTasks(client, tasks);
+    const tasks = await client.tasks.getAll();
+    await runCodesandboxInstallTasks(client, tasks);
 
-      return res.redirect(
-        `https://codesandbox.io/p/sandbox/${sandbox.id}?file=&preview=true`,
-        302,
-      );
-    }
+    return res.redirect(
+      `https://codesandbox.io/p/sandbox/${sandbox.id}?file=&preview=true`,
+      302,
+    );
   } catch (error) {
     if (isNotFoundClientError(error)) {
       console.log(error);


### PR DESCRIPTION
Ensures 'config.codesandbox.templateId' is present before creating a CodeSandbox VM. Returns 400 if missing, preventing errors and potential infinite loops during sandbox initialization.

Previously, if template ID did not exists, the app was stuck the infinite loop. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a simple upfront validation and returns a clear 400 error when `config.codesandbox.templateId` is missing, avoiding a broken sandbox-creation path.
> 
> **Overview**
> The `/codesandbox-vm` endpoint now **requires** `package.json` to define `config.codesandbox.templateId`; if missing, it returns a `400` with a descriptive error instead of attempting sandbox creation.
> 
> Sandbox creation is no longer conditional on `templateId`, making the failure mode explicit and preventing the previous stuck/looping behavior when the template id was absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73ef1e4097bbf5586827f3ad6b84691197bf7a0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->