### PR TITLE
DEV-1661: Connect correct Astro templateId

### DIFF
--- a/examples/astro/package.json
+++ b/examples/astro/package.json
@@ -16,7 +16,7 @@
   },
   "config": {
     "codesandbox": {
-      "templateId": "handsontable-example-astro-17-0-1-438vfj"
+      "templateId": "438vfj"
     },
     "stackblitz": {
       "template": "node"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk configuration-only change affecting example sandbox metadata, with no runtime code or dependency changes.
> 
> **Overview**
> Updates `examples/astro/package.json` to use the correct CodeSandbox `templateId` (switching from the old prefixed ID to the new `438vfj` value).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a04fd30d089eb8a54537c6d8572eed0a1635e5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->