### PR TITLE
Fix Angular CodeSandbox template and redirect arguments

### DIFF
--- a/examples/angular/package.json
+++ b/examples/angular/package.json
@@ -34,7 +34,7 @@
   },
   "config": {
     "codesandbox": {
-      "templateId": "pt_DaDd5XbrEEj1CFVGWwEofc"
+      "templateId": "chnr97"
     }
   }
 }

--- a/render-ms/index.js
+++ b/render-ms/index.js
@@ -249,8 +249,8 @@ app.get("/codesandbox-vm", async (req, res) => {
     const existingFirstLookup = sandboxesByTag.sandboxes[0];
     if (existingFirstLookup) {
       return res.redirect(
-        `https://codesandbox.io/p/sandbox/${existingFirstLookup.id}?file=&preview=true`,
         302,
+        `https://codesandbox.io/p/sandbox/${existingFirstLookup.id}?file=&preview=true`,
       );
     }
 
@@ -275,8 +275,8 @@ app.get("/codesandbox-vm", async (req, res) => {
     const existing = sandboxesByTag.sandboxes[0];
     if (existing) {
       return res.redirect(
-        `https://codesandbox.io/p/sandbox/${existing.id}?file=&preview=true`,
         302,
+        `https://codesandbox.io/p/sandbox/${existing.id}?file=&preview=true`,
       );
     }
 
@@ -354,8 +354,8 @@ app.get("/codesandbox-vm", async (req, res) => {
     await runCodesandboxInstallTasks(client, tasks);
 
     return res.redirect(
-      `https://codesandbox.io/p/sandbox/${sandbox.id}?file=&preview=true`,
       302,
+      `https://codesandbox.io/p/sandbox/${sandbox.id}?file=&preview=true`,
     );
   } catch (error) {
     if (isNotFoundClientError(error)) {


### PR DESCRIPTION
Update the Angular example's CodeSandbox template ID in `package.json` to the correct reference.

Correct the argument order for `res.redirect` calls in `render-ms/index.js` to properly use `(status, url)` when an explicit status code is provided.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates a CodeSandbox template reference and fixes Express `res.redirect` parameter ordering; behavior change is limited to sandbox creation/redirect URLs.
> 
> **Overview**
> Fixes CodeSandbox integration by updating the Angular example’s `config.codesandbox.templateId` to the new template identifier.
> 
> Corrects `res.redirect` calls in `render-ms/index.js` to pass the explicit status code and URL in the proper order, ensuring redirects reliably return `302` to the intended sandbox preview URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 383e0c0b5f9e1b4e59bf6d62c1db43ada3039c91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->