### PR TITLE
feat: Upgrade Handsontable to v17 and update example templates

### DIFF
--- a/examples/next.js/components/Grid.tsx
+++ b/examples/next.js/components/Grid.tsx
@@ -16,7 +16,7 @@ import {
   NumericCellType,
   registerCellType,
 } from 'handsontable/cellTypes';
-import { HotTable, HotColumn } from '@handsontable/react';
+import { HotTable, HotColumn } from '@handsontable/react-wrapper';
 
 import 'handsontable/styles/handsontable.min.css';
 import 'handsontable/styles/ht-theme-main.min.css';

--- a/examples/next.js/package.json
+++ b/examples/next.js/package.json
@@ -9,8 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@handsontable/react": "16.1.1",
-    "handsontable": "16.1.1",
+    "@handsontable/react-wrapper": "17.0.1",
+    "handsontable": "17.0.1",
     "@types/node": "20.6.2",
     "@types/react": "18.2.22",
     "@types/react-dom": "18.2.7",
@@ -26,7 +26,7 @@
   },
   "config": {
     "codesandbox": {
-      "templateId": "pt_B2bQ4EprL9i7KbjaddgRRT"
+      "templateId": "5l26fv"
     },
     "stackblitz": {
       "template": "node"

--- a/examples/next.js/pnpm-lock.yaml
+++ b/examples/next.js/pnpm-lock.yaml
@@ -8,9 +8,9 @@ importers:
 
   .:
     dependencies:
-      '@handsontable/react':
-        specifier: 16.1.1
-        version: 16.1.1(handsontable@16.1.1)
+      '@handsontable/react-wrapper':
+        specifier: 17.0.1
+        version: 17.0.1(handsontable@17.0.1)
       '@types/node':
         specifier: 20.6.2
         version: 20.6.2
@@ -30,8 +30,8 @@ importers:
         specifier: 13.5.1
         version: 13.5.1(eslint@8.49.0)(typescript@5.2.2)
       handsontable:
-        specifier: 16.1.1
-        version: 16.1.1
+        specifier: 17.0.1
+        version: 17.0.1
       next:
         specifier: 13.5.1
         version: 13.5.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -87,11 +87,10 @@ packages:
   '@handsontable/pikaday@1.0.0':
     resolution: {integrity: sha512-1VN6N38t5/DcjJ7y7XUYrDx1LuzvvzlrFdBdMG90Qo1xc8+LXHqbWbsTEm5Ec5gXTEbDEO53vUT35R+2COmOyg==}
 
-  '@handsontable/react@16.1.1':
-    resolution: {integrity: sha512-PexesDmY1Ikuf+aT8WssmakEVyF/ZVyqF7cZdj8cH8ghgln2OmYY7Y1XuJjK2YGKigOBDTm8Fx+ZdG3w2gHfDQ==}
-    deprecated: Handsontable for React is now available as @handsontable/react-wrapper.
+  '@handsontable/react-wrapper@17.0.1':
+    resolution: {integrity: sha512-fzzFIc0tZ8GQzZSQCkdaiAtPr6pLN8Sb/xtcVoEIOGDqJmox90FQadXYL59LuH/sXLzm+eEEWxNI5+HRXvk7hg==}
     peerDependencies:
-      handsontable: '>=16.0.0'
+      handsontable: ^17.0.0
 
   '@humanwhocodes/config-array@0.11.14':
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
@@ -145,24 +144,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@13.5.1':
     resolution: {integrity: sha512-L4qNXSOHeu1hEAeeNsBgIYVnvm0gg9fj2O2Yx/qawgQEGuFBfcKqlmIE/Vp8z6gwlppxz5d7v6pmHs1NB6R37w==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@13.5.1':
     resolution: {integrity: sha512-QVvMrlrFFYvLtABk092kcZ5Mzlmsk2+SV3xYuAu8sbTuIoh0U2+HGNhVklmuYCuM3DAAxdiMQTNlRQmNH11udw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@13.5.1':
     resolution: {integrity: sha512-bBnr+XuWc28r9e8gQ35XBtyi5KLHLhTbEvrSgcWna8atI48sNggjIK8IyiEBO3KIrcUVXYkldAzGXPEYMnKt1g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@13.5.1':
     resolution: {integrity: sha512-EQGeE4S5c9v06jje9gr4UlxqUEA+zrsgPi6kg9VwR+dQHirzbnVJISF69UfKVkmLntknZJJI9XpWPB6q0Z7mTg==}
@@ -301,41 +304,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -540,9 +551,6 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
-
-  core-js@3.48.0:
-    resolution: {integrity: sha512-zpEHTy1fjTMZCKLHUZoVeylt9XrzaIN2rbPXEt0k+q7JE5CkCZdo6bNq55bn24a69CH7ErAVLKijxJja4fw+UQ==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -907,8 +915,8 @@ packages:
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
-  handsontable@16.1.1:
-    resolution: {integrity: sha512-dZEnAR8osq1/3SwB0g3glqGN2SBsOlxiu5p4VyHAQoNpnr/cj31m948iEiog3fiGSpwvQefj/Mfp8oW7Nrxxtg==}
+  handsontable@17.0.1:
+    resolution: {integrity: sha512-N7d/Vv341sGsKq/afsR+Y1EcSD1YCAwpLN245VnmprTGaFtDSBsiu12EsjNPD/1VCvZvN5PLH8Ojsq/TzqhLZQ==}
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -1758,9 +1766,9 @@ snapshots:
 
   '@handsontable/pikaday@1.0.0': {}
 
-  '@handsontable/react@16.1.1(handsontable@16.1.1)':
+  '@handsontable/react-wrapper@17.0.1(handsontable@17.0.1)':
     dependencies:
-      handsontable: 16.1.1
+      handsontable: 17.0.1
 
   '@humanwhocodes/config-array@0.11.14':
     dependencies:
@@ -2187,8 +2195,6 @@ snapshots:
   commander@4.1.1: {}
 
   concat-map@0.0.1: {}
-
-  core-js@3.48.0: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -2720,10 +2726,9 @@ snapshots:
 
   graphemer@1.4.0: {}
 
-  handsontable@16.1.1:
+  handsontable@17.0.1:
     dependencies:
       '@handsontable/pikaday': 1.0.0
-      core-js: 3.48.0
       dompurify: 3.3.1
       moment: 2.30.1
       numbro: 2.5.0

--- a/examples/vue/package.json
+++ b/examples/vue/package.json
@@ -28,7 +28,7 @@
   },
   "config": {
     "codesandbox": {
-      "templateId": "pt_onLXn5ewGYNytd1L5V9n3"
+      "templateId": "53p5q2"
     }
   }
 }


### PR DESCRIPTION
The Next.js example is updated to use Handsontable v17.0.1, including the migration from `@handsontable/react` to the new `@handsontable/react-wrapper` package. CodeSandbox template IDs for both Next.js and Vue examples have also been refreshed to point to the latest versions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to a major dependency upgrade and a React wrapper package migration, which can introduce runtime/API compatibility issues in the Next.js example. Other changes are limited to metadata/lockfile updates.
> 
> **Overview**
> Upgrades the Next.js example from Handsontable `16.1.1` to `17.0.1` and migrates the React integration from `@handsontable/react` to `@handsontable/react-wrapper` (updating the `HotTable`/`HotColumn` import accordingly).
> 
> Refreshes CodeSandbox template IDs for the Next.js and Vue examples, and updates the Next.js `pnpm-lock.yaml` to reflect the new dependencies (including removal of the old `@handsontable/react` entry).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72836459478838fd071e6206b66f0f3aa8c03c66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->