### PR TITLE
fix: Update outdated share capital in LICENSE.txt files

### DIFF
--- a/examples/angular/LICENSE.txt
+++ b/examples/angular/LICENSE.txt
@@ -3,7 +3,7 @@ Copyright (c) HANDSONCODE sp. z o. o.
 HANDSONTABLE is a software distributed by HANDSONCODE sp. z o. o.,
 a Polish corporation, based in Gdynia, Poland, at 96/98 Aleja Zwycięstwa,
 registered with the National Court Register under number 538651,
-EU tax ID number: PL5862294002, share capital: PLN 62,800.00.
+EU tax ID number: PL5862294002, share capital: PLN 67,200.00.
 
 This software is protected by applicable copyright laws, including
 international treaties, and dual-licensed – depending on whether

--- a/examples/ant-design/LICENSE.txt
+++ b/examples/ant-design/LICENSE.txt
@@ -3,7 +3,7 @@ Copyright (c) HANDSONCODE sp. z o. o.
 HANDSONTABLE is a software distributed by HANDSONCODE sp. z o. o.,
 a Polish corporation, based in Gdynia, Poland, at 96/98 Aleja Zwycięstwa,
 registered with the National Court Register under number 538651,
-EU tax ID number: PL5862294002, share capital: PLN 62,800.00.
+EU tax ID number: PL5862294002, share capital: PLN 67,200.00.
 
 This software is protected by applicable copyright laws, including
 international treaties, and dual-licensed – depending on whether

--- a/examples/javascript/LICENSE.txt
+++ b/examples/javascript/LICENSE.txt
@@ -3,7 +3,7 @@ Copyright (c) HANDSONCODE sp. z o. o.
 HANDSONTABLE is a software distributed by HANDSONCODE sp. z o. o.,
 a Polish corporation, based in Gdynia, Poland, at 96/98 Aleja Zwycięstwa,
 registered with the National Court Register under number 538651,
-EU tax ID number: PL5862294002, share capital: PLN 62,800.00.
+EU tax ID number: PL5862294002, share capital: PLN 67,200.00.
 
 This software is protected by applicable copyright laws, including
 international treaties, and dual-licensed – depending on whether

--- a/examples/react-js/LICENSE.txt
+++ b/examples/react-js/LICENSE.txt
@@ -3,7 +3,7 @@ Copyright (c) HANDSONCODE sp. z o. o.
 HANDSONTABLE is a software distributed by HANDSONCODE sp. z o. o.,
 a Polish corporation, based in Gdynia, Poland, at 96/98 Aleja Zwycięstwa,
 registered with the National Court Register under number 538651,
-EU tax ID number: PL5862294002, share capital: PLN 62,800.00.
+EU tax ID number: PL5862294002, share capital: PLN 67,200.00.
 
 This software is protected by applicable copyright laws, including
 international treaties, and dual-licensed – depending on whether


### PR DESCRIPTION
## Summary
- Updated the outdated share capital from PLN 62,800.00 to PLN 67,200.00 in `examples/angular/LICENSE.txt`, `examples/javascript/LICENSE.txt`, `examples/react-js/LICENSE.txt`, and `examples/ant-design/LICENSE.txt`

Task: IT-538

## Test plan
- [x] Verified no other tracked LICENSE.txt files reference the old value

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only legal header updates in example LICENSE files with no runtime or security impact.
> 
> **Overview**
> Updates the **HANDSONCODE** corporate **share capital** line in four example app `LICENSE.txt` files from **PLN 62,800.00** to **PLN 67,200.00**.
> 
> Affected paths: `examples/angular`, `examples/ant-design`, `examples/javascript`, and `examples/react-js`. No license terms or dual-licensing text change—only the registered capital figure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe1ce386dd4612c29e76f135f09a4b374f125200. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->